### PR TITLE
Noticed an issue with the non-Latin file names, proposing a fix

### DIFF
--- a/imsanity.php
+++ b/imsanity.php
@@ -320,8 +320,8 @@ function imsanity_convert_to_jpg( $type, $params ) {
 
 	// We need to change the extension from the original to .jpg so we have to ensure it will be a unique filename.
 	$uploads     = wp_upload_dir();
-	$oldfilename = basename( $params['file'] );
-	$newfilename = basename( str_ireplace( '.' . $type, '.jpg', $oldfilename ) );
+	$oldfilename = wp_basename( $params['file'] );
+	$newfilename = wp_basename( str_ireplace( '.' . $type, '.jpg', $oldfilename ) );
 	$newfilename = wp_unique_filename( $uploads['path'], $newfilename );
 
 	$quality = imsanity_get_option( 'imsanity_quality', IMSANITY_DEFAULT_QUALITY );


### PR DESCRIPTION
Hi nosilver4u,

I encountered a small issue with this plugin recently. When I upload a BMP file that has a non-Latin name (like, a Cyrillic name in my case), after the conversion to JPG the resulting name misses the non-Latin characters (if the whole name is non-Latin, the result is "unnamed-file.jpg").

The issue is caused by the PHP **basename()** function that has a limited support for multibyte strings; it requires the locale to be explicitly set, which is not always possible. There are several comments at its documentation page on this.
Wordpress has a replacement **wp_basename()** function [introduced in 2017](https://core.trac.wordpress.org/ticket/43170) that handles non-Latin characters correctly. So I'm suggesting to use it here.

Thanks for the very useful plugin!
Alex